### PR TITLE
docs: update readme to include bibtex entry 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TSNEx
+# tSNEx
 
 **TSNEx** is a lightweight, high-performance Python library for t-Distributed Stochastic Neighbor Embedding (t-SNE) built on top of JAX. Leveraging the power of JAX, `tsnex` offers JIT compilation, automatic differentiation, and hardware acceleration support to efficiently handle high-dimensional data for visualization and clustering tasks.
 
@@ -22,6 +22,17 @@ X_embedded = tsnex.transform(X, n_components=2)
 
 ## Contributing
 We welcome contributions to **TSNEx**! Whether it's adding new features, improving documentation, or reporting issues, please feel free to make a pull request and/or open an issue.
+
+## Citation
+If you use `tsnex` in your research and need to reference it, please cite it as follows:
+```
+@software{alonso_tsnex,
+  author = {Alonso, Albert},
+  title = {tsnex: Minimal t-distributed stochastic neighbor embedding (t-SNE) implementation in JAX},
+  url = {https://github.com/alonfnt/tsnex},
+  version = {0.0.1}
+}
+```
 
 ## License
 TSNEx is licensed under the MIT License. See the ![LICENSE](LICENSE) file for more details.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# tSNEx
+# tsnex
 
-**TSNEx** is a lightweight, high-performance Python library for t-Distributed Stochastic Neighbor Embedding (t-SNE) built on top of JAX. Leveraging the power of JAX, `tsnex` offers JIT compilation, automatic differentiation, and hardware acceleration support to efficiently handle high-dimensional data for visualization and clustering tasks.
+**t-SNEx** is a lightweight, high-performance Python library for t-Distributed Stochastic Neighbor Embedding (t-SNE) built on top of JAX. Leveraging the power of JAX, `tsnex` offers JIT compilation, automatic differentiation, and hardware acceleration support to efficiently handle high-dimensional data for visualization and clustering tasks.
 
 ## Installation
 Use the package manager [pip](https://pypi.org/project/tsnex/) to install `tsnex`.


### PR DESCRIPTION
It is common for research projects to use software such as tsnex, and some journals require authors to cite the libraries they use. 
Now tsnex has a quick citation entry to ease the process.