### PR TITLE
build: update minimum Python version to 3.10

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "tsnex"
 version = "0.0.1"
 description = "Minimal t-distributed stochastic neighbor embedding (t-SNE) implementation in JAX."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     {name = "Albert Alonso", email = "alonfnt@pm.me"},
     {name = "Antonio Matas Gil"}
@@ -19,9 +19,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
 ]
 
 [project.urls]


### PR DESCRIPTION
* Drops support for 3.9.
* The CI now test for (3.10, 3.11, 3.12 and 3.13).