### PR TITLE
build: update version to 0.0.3

### DIFF
--- a/tsnex/__init__.py
+++ b/tsnex/__init__.py
@@ -1,5 +1,5 @@
 from .tsne import transform
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 
 __all__ = ['transform']


### PR DESCRIPTION
Current PyPi version (0.0.2) is broken #16.

We need to publish the fixed one.