### PR TITLE
fix: sigma was wrongly computed

### DIFF
--- a/tsnex/tsne_test.py
+++ b/tsnex/tsne_test.py
@@ -38,7 +38,7 @@ def test_euclidean_distance(x, y, expected):
     [
         (
             jnp.array([[0.0, 0.0], [2.0, 0.0], [4.0, 0.0]]),
-            2.0,
+            jnp.array([2.0, 2.0, 2.0]),
             jnp.array([
                 [0.0, 0.82, 0.18],
                 [0.5, 0.0, 0.5],


### PR DESCRIPTION
`tsnex` was not working as expected before #19 

Now, a quick test on the MNIST dataset shows it working again.

Here's a MRE (Minimal reproducible example)
```python
from sklearn import datasets, manifold
import matplotlib.pyplot as plt
import tsnex
import jax.numpy as jnp

X, y = datasets.load_digits(n_class=7, return_X_y=True)
X_sklearn = manifold.TSNE(n_components=2).fit_transform(X)
X_tsnex = tsnex.transform(jnp.array(X), n_components=2)

fig, axes = plt.subplots(1, 2, figsize=(10, 5))
axes[0].scatter(X_sklearn[:, 0], X_sklearn[:, 1], c=y)
axes[0].set_title("sklearn TSNE")
axes[1].scatter(X_tsnex[:, 0], X_tsnex[:, 1], c=y)
axes[1].set_title("tsnex TSNE")
plt.show()
```

yields

![tsnex_vs_sklearn](https://github.com/user-attachments/assets/c45e25ca-005a-48a3-bd2b-3c5206ce1f35)
