### PR TITLE
build: add schedule testing of dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: pip
-    directory: "/"
-    schedule:
-      interval: weekly
-      timezone: CET
-    open-pull-requests-limit: 10
-    

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,6 +6,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+    - cron: "0 7 * * 0" # Every Sunday at 07:00 UTC
 
 jobs:
   build:


### PR DESCRIPTION
Since I don't want to constrain the versions of `jax` and `pcax` that I use, I'll just test every week until it breaks.

Likewise, depandabot wasn't doing much (since the version are not pinned), so I'll remove it.